### PR TITLE
Remove legacy local/remote paths; daemon-only CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,28 @@ A PNG clipboard bridge for [Tailscale](https://tailscale.com/) + SSH.
 
 Take a screenshot on one node and paste it into apps on another node over SSH.
 
-## How it works now (automatic daemon mode)
+## How it works (daemon mode)
 
-`tassh` now uses a single daemon per node.
+`tassh` uses a single daemon per node.
 
 1. `tassh daemon` runs on each node.
-2. When you start an SSH session, SSH `LocalCommand` runs `tassh notify` on the source node.
+2. On SSH connect, SSH `LocalCommand` runs `tassh notify` on the source node.
 3. The source daemon tracks SSH sessions and connects to destination daemon(s) automatically.
 4. Clipboard PNG frames are forwarded over TCP on the Tailscale network.
-5. Destination node writes frames into an X11 clipboard (Xvfb if needed) for paste.
+5. Destination node writes frames into clipboard (`xclip` on X11/Xvfb, `wl-copy` on Wayland).
 
-You do not need to manually run `tassh local` / `tassh remote` for normal use.
+```
+[Screenshot] -> tassh daemon -> TCP/Tailscale -> tassh daemon -> remote clipboard -> Ctrl-V
+```
 
 ## Prerequisites
 
 - [Rust](https://rustup.rs/) (build/install)
 - [Tailscale](https://tailscale.com/) (node-to-node network path)
 - OpenSSH client/server
-- `xclip` and `xvfb` available on nodes that may receive clipboard frames
+- Clipboard tools:
+  - X11/headless: `xclip` (and `xvfb` for headless)
+  - Wayland: `wl-copy` (`wl-clipboard` package)
 
 ## Install
 
@@ -58,9 +62,7 @@ Host *
     LocalCommand tassh notify --host %h --port %p --ssh-pid $PPID
 ```
 
-- Prints a shell snippet to source `~/.tassh/display` inside SSH sessions
-
-Add the display snippet to your shell profile (`~/.zshrc` or `~/.bashrc`), then open a new SSH session.
+- Ensures your shell profiles source `~/.tassh/display` in SSH sessions
 
 ## Usage
 
@@ -75,22 +77,12 @@ Check status at any time:
 tassh status
 ```
 
-## Legacy commands
-
-`tassh local` and `tassh remote` still exist for compatibility, but are deprecated in favor of daemon mode.
-
 ## Systemd and logs
 
 Check daemon logs:
 
 ```bash
 journalctl --user -u tassh-daemon.service -f
-```
-
-If migrating from old units:
-
-```bash
-systemctl --user disable --now tassh-local.service tassh-remote.service
 ```
 
 ## Integration harness (Docker)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,11 +10,7 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
-    /// Run as local daemon (watches clipboard, sends frames) [DEPRECATED: use `daemon`]
-    Local(LocalArgs),
-    /// Run as remote daemon (receives frames, writes clipboard) [DEPRECATED: use `daemon`]
-    Remote(RemoteArgs),
-    /// Run unified daemon (auto-connects on SSH, replaces local/remote)
+    /// Run unified clipboard relay daemon (auto-connects on SSH)
     Daemon(DaemonArgs),
     /// Notify daemon of SSH connection (called by LocalCommand, fast fire-and-forget)
     Notify(NotifyArgs),
@@ -28,31 +24,6 @@ pub enum Commands {
         #[command(subcommand)]
         target: SetupTarget,
     },
-}
-
-#[derive(Debug, Parser)]
-pub struct LocalArgs {
-    /// Remote host to connect to.
-    /// Accepts a Tailscale hostname or IP (e.g. `100.x.x.x` or `my-machine`).
-    /// Port can be appended as `host:port` to override the default.
-    #[arg(long, env = "TASSH_REMOTE_HOST")]
-    pub remote: String,
-
-    /// Port to connect on
-    #[arg(long, env = "TASSH_PORT", default_value = "9877")]
-    pub port: u16,
-}
-
-#[derive(Debug, Parser)]
-pub struct RemoteArgs {
-    /// Port to listen on
-    #[arg(long, env = "TASSH_PORT", default_value = "9877")]
-    pub port: u16,
-
-    /// Address to bind the server to.
-    /// If not provided, auto-detects the Tailscale IPv4 address via `tailscale ip -4`.
-    #[arg(long, env = "TASSH_BIND")]
-    pub bind: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -86,34 +57,8 @@ pub struct InjectArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum SetupTarget {
-    /// Set up tassh-local.service on this machine (clipboard watcher) [DEPRECATED: use `daemon`]
-    Local(SetupLocalArgs),
-    /// Set up tassh-remote.service on this machine (clipboard receiver) [DEPRECATED: use `daemon`]
-    Remote(SetupRemoteArgs),
     /// Set up tassh-daemon.service and SSH config (recommended)
     Daemon(SetupDaemonArgs),
-}
-
-#[derive(Debug, Parser)]
-pub struct SetupLocalArgs {
-    /// Remote host to connect to (Tailscale IP or hostname)
-    #[arg(long)]
-    pub remote: String,
-
-    /// Port to connect on
-    #[arg(long, default_value = "9877")]
-    pub port: u16,
-}
-
-#[derive(Debug, Parser)]
-pub struct SetupRemoteArgs {
-    /// Address to bind the server to (Tailscale IP)
-    #[arg(long)]
-    pub bind: String,
-
-    /// Port to listen on
-    #[arg(long, default_value = "9877")]
-    pub port: u16,
 }
 
 #[derive(Debug, Parser)]

--- a/src/display.rs
+++ b/src/display.rs
@@ -37,8 +37,8 @@ impl DisplayManager {
     /// 3. Neither → headless path: clean stale locks, spawn Xvfb, publish `~/.tassh/display`
     ///
     /// When `force_xvfb` is true, skip Wayland/X11 detection and always spawn Xvfb.
-    /// This is used by `tassh remote` so that SSH sessions can read the clipboard
-    /// via the published `~/.tassh/display` file, even on machines with a desktop session.
+    /// This mode is useful when callers want SSH sessions to always use the published
+    /// `~/.tassh/display` clipboard, even on machines with a desktop session.
     pub async fn detect_and_init(force_xvfb: bool) -> anyhow::Result<Self> {
         if !force_xvfb {
             // 1. Try Wayland

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,86 +28,6 @@ async fn main() {
     let cli = cli::Cli::parse();
 
     match cli.command {
-        Commands::Local(args) => {
-            // Parse `host:port` or bare host from --remote.
-            let (remote_host, port) = parse_remote(&args.remote, args.port);
-
-            let (tx, rx) = tokio::sync::mpsc::channel::<protocol::Frame>(16);
-
-            // Spawn clipboard watcher — polls local clipboard, wraps PNG bytes in Frame,
-            // sends over mpsc channel to the transport client.
-            let watch_handle = tokio::spawn(async move {
-                if let Err(e) = clipboard::watch_clipboard(tx, None, None).await {
-                    tracing::error!("clipboard watcher error: {e}");
-                }
-            });
-
-            // Run transport client and handle Ctrl-C for clean shutdown.
-            tokio::select! {
-                result = transport::client(&remote_host, port, rx) => {
-                    if let Err(e) = result {
-                        eprintln!("transport error: {e}");
-                        std::process::exit(1);
-                    }
-                }
-                _ = tokio::signal::ctrl_c() => {
-                    tracing::info!("Ctrl-C received, shutting down");
-                }
-            }
-
-            // Abort the watcher if still running (e.g. after Ctrl-C).
-            watch_handle.abort();
-        }
-        Commands::Remote(args) => {
-            // Use explicit --bind if provided; otherwise signal auto-detection.
-            let bind_addr = args.bind.as_deref().unwrap_or("auto").to_owned();
-
-            // Always force Xvfb so SSH sessions can read the clipboard via
-            // ~/.tassh/display, even on machines with a Wayland/X11 desktop.
-            let display_mgr = match display::DisplayManager::detect_and_init(true).await {
-                Ok(m) => m,
-                Err(e) => {
-                    eprintln!("display init error: {e}");
-                    std::process::exit(1);
-                }
-            };
-
-            // Verify required clipboard tools are installed before accepting connections.
-            if let Err(e) = clipboard::check_clipboard_tools(&display_mgr.env).await {
-                eprintln!("clipboard tool check failed: {e}");
-                display_mgr.shutdown().await;
-                std::process::exit(1);
-            }
-
-            // Set up SIGTERM handler for clean shutdown.
-            let mut sigterm =
-                match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        eprintln!("failed to install SIGTERM handler: {e}");
-                        display_mgr.shutdown().await;
-                        std::process::exit(1);
-                    }
-                };
-
-            // Run server loop; handle SIGTERM and Ctrl-C for clean shutdown.
-            tokio::select! {
-                result = transport::server(&bind_addr, args.port, display_mgr.env) => {
-                    if let Err(e) = result {
-                        eprintln!("server error: {e}");
-                    }
-                }
-                _ = sigterm.recv() => {
-                    tracing::info!("SIGTERM received, shutting down");
-                }
-                _ = tokio::signal::ctrl_c() => {
-                    tracing::info!("Ctrl-C received, shutting down");
-                }
-            }
-
-            // Shutdown: kill Xvfb (if any) and remove ~/.tassh/display.
-            display_mgr.shutdown().await;
-        }
         Commands::Daemon(args) => {
             if let Err(e) = daemon::run_daemon(args.port).await {
                 eprintln!("daemon error: {e}");
@@ -137,8 +57,6 @@ async fn main() {
         }
         Commands::Setup { target } => {
             let result = match target {
-                cli::SetupTarget::Local(args) => setup::run_setup_local(&args),
-                cli::SetupTarget::Remote(args) => setup::run_setup_remote(&args),
                 cli::SetupTarget::Daemon(args) => setup::run_setup_daemon(&args),
             };
             if let Err(e) = result {
@@ -243,16 +161,4 @@ async fn run_status() -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-/// Split a `host:port` string into its components.
-/// If no colon is present the supplied `default_port` is used.
-fn parse_remote(remote: &str, default_port: u16) -> (String, u16) {
-    if let Some(colon) = remote.rfind(':') {
-        let host = &remote[..colon];
-        if let Ok(p) = remote[colon + 1..].parse::<u16>() {
-            return (host.to_owned(), p);
-        }
-    }
-    (remote.to_owned(), default_port)
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 use anyhow::{bail, Context};
 
-use crate::cli::{SetupDaemonArgs, SetupLocalArgs, SetupRemoteArgs};
+use crate::cli::SetupDaemonArgs;
 
 // ---------------------------------------------------------------------------
 // Path helpers
@@ -28,61 +28,6 @@ fn unit_dir() -> PathBuf {
 // ---------------------------------------------------------------------------
 // Unit file generators
 // ---------------------------------------------------------------------------
-
-fn tassh_local_unit(remote: &str, port: u16) -> String {
-    let bin = binary_path();
-    // If remote already contains a colon it may be host:port — split and use those values.
-    let exec_start = if let Some(colon) = remote.rfind(':') {
-        let host = &remote[..colon];
-        let embedded_port = remote[colon + 1..].parse::<u16>().unwrap_or(port);
-        format!(
-            "{} local --remote {} --port {}",
-            bin.display(),
-            host,
-            embedded_port
-        )
-    } else {
-        format!(
-            "{} local --remote {} --port {}",
-            bin.display(),
-            remote,
-            port
-        )
-    };
-
-    format!(
-        "[Unit]\n\
-         Description=tassh local clipboard relay\n\
-         After=network.target\n\
-         \n\
-         [Service]\n\
-         ExecStart={exec_start}\n\
-         Restart=always\n\
-         RestartSec=5\n\
-         \n\
-         [Install]\n\
-         WantedBy=default.target\n"
-    )
-}
-
-fn tassh_remote_unit(bind: &str, port: u16) -> String {
-    let bin = binary_path();
-    let exec_start = format!("{} remote --bind {} --port {}", bin.display(), bind, port);
-
-    format!(
-        "[Unit]\n\
-         Description=tassh remote clipboard relay\n\
-         After=network.target\n\
-         \n\
-         [Service]\n\
-         ExecStart={exec_start}\n\
-         Restart=always\n\
-         RestartSec=5\n\
-         \n\
-         [Install]\n\
-         WantedBy=default.target\n"
-    )
-}
 
 // ---------------------------------------------------------------------------
 // Shell snippet
@@ -169,81 +114,8 @@ fn run_systemctl(args: &[&str]) -> anyhow::Result<()> {
 }
 
 // ---------------------------------------------------------------------------
-// Core setup orchestration
-// ---------------------------------------------------------------------------
-
-fn run_setup(service_name: &str, unit_content: &str) -> anyhow::Result<()> {
-    let dir = unit_dir();
-    std::fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
-
-    let unit_path = dir.join(service_name);
-    std::fs::write(&unit_path, unit_content)
-        .with_context(|| format!("failed to write {}", unit_path.display()))?;
-    println!("Wrote {}", unit_path.display());
-
-    run_systemctl(&["--user", "daemon-reload"])?;
-    run_systemctl(&["--user", "enable", service_name])?;
-    run_systemctl(&["--user", "start", service_name])?;
-
-    // loginctl enable-linger: failure is a warning, not a fatal error.
-    let linger_status = Command::new("loginctl").arg("enable-linger").status();
-    match linger_status {
-        Ok(s) if s.success() => {}
-        Ok(s) => {
-            eprintln!(
-                "warning: loginctl enable-linger exited with status {} — \
-                 linger may need to be enabled manually",
-                s
-            );
-        }
-        Err(e) => {
-            eprintln!(
-                "warning: loginctl enable-linger failed: {e} — \
-                 linger may need to be enabled manually"
-            );
-        }
-    }
-
-    install_shell_snippets();
-    println!();
-    println!("To follow logs: journalctl --user -u {} -f", service_name);
-
-    Ok(())
-}
-
-// ---------------------------------------------------------------------------
 // Public entry points
 // ---------------------------------------------------------------------------
-
-/// Install tassh-local.service (clipboard watcher → sends frames to remote).
-pub fn run_setup_local(args: &SetupLocalArgs) -> anyhow::Result<()> {
-    let bin = binary_path();
-    if !bin.exists() {
-        bail!(
-            "binary not found at {}. Run `cargo install --path .` first.",
-            bin.display()
-        );
-    }
-    run_setup(
-        "tassh-local.service",
-        &tassh_local_unit(&args.remote, args.port),
-    )
-}
-
-/// Install tassh-remote.service (receives frames → writes clipboard).
-pub fn run_setup_remote(args: &SetupRemoteArgs) -> anyhow::Result<()> {
-    let bin = binary_path();
-    if !bin.exists() {
-        bail!(
-            "binary not found at {}. Run `cargo install --path .` first.",
-            bin.display()
-        );
-    }
-    run_setup(
-        "tassh-remote.service",
-        &tassh_remote_unit(&args.bind, args.port),
-    )
-}
 
 // ---------------------------------------------------------------------------
 // Daemon setup helpers


### PR DESCRIPTION
## Summary
- remove `tassh local` and `tassh remote` command paths
- remove `setup local`/`setup remote` so setup is daemon-only
- update README for daemon-only workflow
- remove legacy migration notes from setup output

## Verification
- cargo fmt --all
- cargo test -q
